### PR TITLE
Fix esm syntax for node 18 compatibility

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,10 @@
   publish = "dist"
 
 [build.environment]
-  NODE_VERSION = "18"
+  NODE_VERSION = "20"
+
+[functions]
+  node_bundler = "esbuild"
 
 [[redirects]]
   from = "/api/*"

--- a/netlify/functions/analytics-data.js
+++ b/netlify/functions/analytics-data.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   if (event.httpMethod === "OPTIONS") {
     return {
       statusCode: 200,

--- a/netlify/functions/dashboard-data.js
+++ b/netlify/functions/dashboard-data.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   if (event.httpMethod === "OPTIONS") {
     return {
       statusCode: 200,

--- a/netlify/functions/fetch-profile-metrics.js
+++ b/netlify/functions/fetch-profile-metrics.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   if (event.httpMethod === 'OPTIONS') {
     return {
       statusCode: 200,

--- a/netlify/functions/linkedin-changelog.js
+++ b/netlify/functions/linkedin-changelog.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   if (event.httpMethod === "OPTIONS") {
     return {
       statusCode: 200,

--- a/netlify/functions/linkedin-historical-posts.js
+++ b/netlify/functions/linkedin-historical-posts.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   if (event.httpMethod === "OPTIONS") {
     return {
       statusCode: 200,

--- a/netlify/functions/linkedin-media-download.js
+++ b/netlify/functions/linkedin-media-download.js
@@ -1,6 +1,6 @@
 // netlify/functions/linkedin-media-download.js
 
-export async function handler(event) {
+exports.handler = async function(event) {
   // Handle CORS preflight
   if (event.httpMethod === "OPTIONS") {
     return {

--- a/netlify/functions/linkedin-oauth-callback.js
+++ b/netlify/functions/linkedin-oauth-callback.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   console.log('OAuth callback called with:', event.queryStringParameters);
   
   const { code, state } = event.queryStringParameters || {};

--- a/netlify/functions/linkedin-oauth-start.js
+++ b/netlify/functions/linkedin-oauth-start.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   console.log('OAuth start called with:', event.queryStringParameters);
   
   const { type = 'basic' } = event.queryStringParameters || {};

--- a/netlify/functions/linkedin-post.js
+++ b/netlify/functions/linkedin-post.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   if (event.httpMethod === "OPTIONS") {
     return {
       statusCode: 200,

--- a/netlify/functions/linkedin-profile.js
+++ b/netlify/functions/linkedin-profile.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   if (event.httpMethod === 'OPTIONS') {
     return {
       statusCode: 200,

--- a/netlify/functions/linkedin-snapshot.js
+++ b/netlify/functions/linkedin-snapshot.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   if (event.httpMethod === "OPTIONS") {
     return {
       statusCode: 200,

--- a/netlify/functions/synergy-comments.js
+++ b/netlify/functions/synergy-comments.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   if (event.httpMethod === "OPTIONS") {
     return {
       statusCode: 200,

--- a/netlify/functions/synergy-partners.js
+++ b/netlify/functions/synergy-partners.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   if (event.httpMethod === "OPTIONS") {
     return {
       statusCode: 200,

--- a/netlify/functions/synergy-posts.js
+++ b/netlify/functions/synergy-posts.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   if (event.httpMethod === "OPTIONS") {
     return {
       statusCode: 200,

--- a/netlify/functions/synergy-suggest-comment.js
+++ b/netlify/functions/synergy-suggest-comment.js
@@ -1,4 +1,4 @@
-export async function handler(event, context) {
+exports.handler = async function(event, context) {
   if (event.httpMethod === "OPTIONS") {
     return {
       statusCode: 200,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "vite-react-typescript-starter",
   "private": true,
   "version": "0.0.0",
-  "type": "module",
   "scripts": {
     "dev": "vite",
     "dev:netlify": "netlify dev",
@@ -38,5 +37,8 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.2"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+module.exports = {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
Fix Netlify build failures by converting config files and functions to CommonJS and upgrading Node.js to version 20.

The build was failing due to `SyntaxError: Unexpected token 'export'` because Node 18 (Netlify's default) expects CommonJS for config files and functions. This PR converts `postcss.config.js`, `tailwind.config.js`, and all Netlify functions to CommonJS, and updates `netlify.toml` and `package.json` to use Node 20, which is required by some dependencies like `react-router`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd572a78-7ea2-4657-9953-c33a4b2102b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd572a78-7ea2-4657-9953-c33a4b2102b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>